### PR TITLE
Restore schedule add button with monthly repeat

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -52,6 +52,7 @@ class StudentForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['parent'].queryset = User.objects.filter(groups__name='Parent').order_by('username')
+        self.fields['student_type'].initial = 'child'
         if self.instance and self.instance.pk:
             self.fields['student_type'].initial = 'adult' if self.instance.is_adult else 'child'
             if self.instance.is_adult and self.instance.account_user:
@@ -161,11 +162,20 @@ class SubscriptionForm(forms.ModelForm):
         fields = ['child', 'sub_type', 'lessons_remaining', 'price', 'paid']
 
 class TrainingSessionForm(forms.ModelForm):
+    fill_month = forms.BooleanField(
+        required=False,
+        label='Заполнить на месяц',
+        widget=forms.CheckboxInput(attrs={'class': 'form-check-input'})
+    )
+
     class Meta:
         model = TrainingSession
         fields = ['start', 'duration_minutes', 'participants', 'notes']
         widgets = {
-            'start': forms.DateTimeInput(attrs={'type': 'datetime-local'}),
+            'start': forms.DateTimeInput(attrs={'type': 'datetime-local', 'class': 'form-control'}),
+            'duration_minutes': forms.NumberInput(attrs={'class': 'form-control'}),
+            'participants': forms.SelectMultiple(attrs={'class': 'form-select'}),
+            'notes': forms.Textarea(attrs={'class': 'form-control', 'rows': 2}),
         }
 
 class AddVisitForm(forms.Form):

--- a/core/templates/admin/sessions_week.html
+++ b/core/templates/admin/sessions_week.html
@@ -13,6 +13,9 @@
     </h4>
 
     <div class="d-flex gap-2">
+      <a class="btn btn-sm btn-primary" data-bs-toggle="collapse" href="#sessionForm" role="button" aria-expanded="false" aria-controls="sessionForm">
+        Добавить занятие
+      </a>
       <a class="btn btn-sm btn-outline-secondary"
          href="{% url 'sessions_week' %}{% if prev_start %}?start={{ prev_start|date:'Y-m-d' }}{% endif %}">
         ← Предыдущая
@@ -21,6 +24,24 @@
          href="{% url 'sessions_week' %}{% if next_start %}?start={{ next_start|date:'Y-m-d' }}{% endif %}">
         Следующая →
       </a>
+    </div>
+  </div>
+
+  <div class="collapse mb-3" id="sessionForm">
+    <div class="card card-body">
+      <form method="post" action="{% url 'session_create' %}">
+        {% csrf_token %}
+        <div class="row g-2">
+          <div class="col-md-3">{{ form.start.label_tag }}{{ form.start }}</div>
+          <div class="col-md-2">{{ form.duration_minutes.label_tag }}{{ form.duration_minutes }}</div>
+          <div class="col-md-4">{{ form.participants.label_tag }}{{ form.participants }}</div>
+          <div class="col-md-3">{{ form.notes.label_tag }}{{ form.notes }}</div>
+          <div class="col-md-3 form-check mt-2">{{ form.fill_month }} {{ form.fill_month.label_tag }}</div>
+        </div>
+        <div class="mt-3">
+          <button type="submit" class="btn btn-primary btn-sm">Сохранить</button>
+        </div>
+      </form>
     </div>
   </div>
 

--- a/core/views.py
+++ b/core/views.py
@@ -144,7 +144,21 @@ def session_create(request):
     if request.method == 'POST':
         form = TrainingSessionForm(request.POST)
         if form.is_valid():
-            form.save()
+            session = form.save()
+            if form.cleaned_data.get('fill_month'):
+                start = session.start
+                duration = session.duration_minutes
+                notes = session.notes
+                participants = session.participants.all()
+                next_start = start + timedelta(days=7)
+                while next_start.month == start.month:
+                    new_session = TrainingSession.objects.create(
+                        start=next_start,
+                        duration_minutes=duration,
+                        notes=notes,
+                    )
+                    new_session.participants.set(participants)
+                    next_start += timedelta(days=7)
             messages.success(request, 'Занятие создано')
             return redirect('sessions_week')
     else:


### PR DESCRIPTION
## Summary
- Reintroduce add session button on weekly schedule with collapsible form
- Allow creating sessions across remaining month via new checkbox

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a403b1155483278a31e3bcfa2b84ca