### PR TITLE
style: restyle training session form

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -171,11 +171,34 @@ class TrainingSessionForm(forms.ModelForm):
     class Meta:
         model = TrainingSession
         fields = ['start', 'duration_minutes', 'participants', 'notes']
+        labels = {
+            'start': 'Дата и время',
+            'duration_minutes': 'Длительность (мин)',
+            'participants': 'Участники',
+            'notes': 'Примечания',
+        }
         widgets = {
-            'start': forms.DateTimeInput(attrs={'type': 'datetime-local', 'class': 'form-control'}),
-            'duration_minutes': forms.NumberInput(attrs={'class': 'form-control'}),
-            'participants': forms.SelectMultiple(attrs={'class': 'form-select'}),
-            'notes': forms.Textarea(attrs={'class': 'form-control', 'rows': 2}),
+            'start': forms.DateTimeInput(
+                attrs={'type': 'datetime-local', 'class': 'form-control'}
+            ),
+            'duration_minutes': forms.NumberInput(
+                attrs={
+                    'class': 'form-control stepper-input',
+                    'min': 30,
+                    'max': 180,
+                    'step': 15,
+                }
+            ),
+            'participants': forms.SelectMultiple(
+                attrs={'class': 'form-select', 'size': 5}
+            ),
+            'notes': forms.Textarea(
+                attrs={
+                    'class': 'form-control',
+                    'rows': 2,
+                    'placeholder': 'Например: тема занятия',
+                }
+            ),
         }
 
 class AddVisitForm(forms.Form):

--- a/core/templates/admin/sessions_week.html
+++ b/core/templates/admin/sessions_week.html
@@ -28,20 +28,57 @@
   </div>
 
   <div class="collapse mb-3" id="sessionForm">
-    <div class="card card-body">
-      <form method="post" action="{% url 'session_create' %}">
-        {% csrf_token %}
-        <div class="row g-2">
-          <div class="col-md-3">{{ form.start.label_tag }}{{ form.start }}</div>
-          <div class="col-md-2">{{ form.duration_minutes.label_tag }}{{ form.duration_minutes }}</div>
-          <div class="col-md-4">{{ form.participants.label_tag }}{{ form.participants }}</div>
-          <div class="col-md-3">{{ form.notes.label_tag }}{{ form.notes }}</div>
-          <div class="col-md-3 form-check mt-2">{{ form.fill_month }} {{ form.fill_month.label_tag }}</div>
-        </div>
-        <div class="mt-3">
-          <button type="submit" class="btn btn-primary btn-sm">Сохранить</button>
-        </div>
-      </form>
+    <div class="card shadow-sm border-0">
+      <div class="card-header" style="background:#d8f3dc;">
+        <h5 class="m-0">Новое занятие</h5>
+      </div>
+      <div class="card-body">
+        <form method="post" action="{% url 'session_create' %}" class="grid-form">
+          {% csrf_token %}
+
+          <div class="row g-3 align-items-center mb-3">
+            <div class="col-12 col-sm-4">
+              <label class="form-label mb-0" for="{{ form.start.id_for_label }}">{{ form.start.label }}</label>
+            </div>
+            <div class="col-12 col-sm-8">{{ form.start }}</div>
+          </div>
+
+          <div class="row g-3 align-items-center mb-3">
+            <div class="col-12 col-sm-4">
+              <label class="form-label mb-0" for="{{ form.duration_minutes.id_for_label }}">{{ form.duration_minutes.label }}</label>
+            </div>
+            <div class="col-12 col-sm-8">
+              <div class="stepper">
+                <button type="button" class="stepper-btn" data-step="-15">−</button>
+                {{ form.duration_minutes }}
+                <button type="button" class="stepper-btn" data-step="15">+</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="row g-3 align-items-start mb-3">
+            <div class="col-12 col-sm-4">
+              <label class="form-label mb-0" for="{{ form.participants.id_for_label }}">{{ form.participants.label }}</label>
+            </div>
+            <div class="col-12 col-sm-8">{{ form.participants }}</div>
+          </div>
+
+          <div class="row g-3 align-items-start mb-3">
+            <div class="col-12 col-sm-4">
+              <label class="form-label mb-0" for="{{ form.notes.id_for_label }}">{{ form.notes.label }}</label>
+            </div>
+            <div class="col-12 col-sm-8">{{ form.notes }}</div>
+          </div>
+
+          <div class="form-check mb-3">
+            {{ form.fill_month }} {{ form.fill_month.label_tag }}
+          </div>
+
+          <div class="text-end">
+            <button type="submit" class="btn btn-success px-4">Сохранить</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- make training session form labels and placeholders consistent with other forms
- redesign weekly schedule creation card with grid layout and stepper controls

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a40a0d7774832798c8ea9bfd750abe