### PR TITLE
Require password change on first login

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -24,6 +24,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'core.middleware.ForcePasswordChangeMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,10 +1,13 @@
 from django.contrib import admin
 from django.urls import path, include
 from django.contrib.auth import views as auth_views
+from core.views import CustomLoginView, CustomPasswordChangeView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('login/', auth_views.LoginView.as_view(template_name='login.html'), name='login'),
+    path('login/', CustomLoginView.as_view(), name='login'),
     path('logout/', auth_views.LogoutView.as_view(next_page='login'), name='logout'),
+    path('password_change/', CustomPasswordChangeView.as_view(), name='password_change'),
+    path('password_change/done/', auth_views.PasswordChangeDoneView.as_view(template_name='password_change_done.html'), name='password_change_done'),
     path('', include('core.urls')),
 ]

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django.shortcuts import redirect
+from django.urls import reverse
+
+
+class ForcePasswordChangeMiddleware:
+    """Перенаправляет на смену пароля, если она обязательна."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.user.is_authenticated and request.session.get('force_password_change'):
+            allowed = {
+                reverse('password_change'),
+                reverse('password_change_done'),
+                reverse('logout'),
+            }
+            static_url = '/' + settings.STATIC_URL.lstrip('/')
+            if request.path not in allowed and not request.path.startswith(static_url):
+                return redirect('password_change')
+        return self.get_response(request)

--- a/core/templates/password_change.html
+++ b/core/templates/password_change.html
@@ -4,18 +4,29 @@
   <div class="col-md-4">
     <h3 class="mb-3">Смена пароля</h3>
     <form method="post">{% csrf_token %}
-      {{ form.non_field_errors }}
+      {% if form.non_field_errors %}
+        <div class="text-danger small mb-3">{{ form.non_field_errors|striptags }}</div>
+      {% endif %}
       <div class="mb-3">
-        <label class="form-label">Старый пароль</label>
-        {{ form.old_password }}
+        <label class="form-label" for="{{ form.old_password.id_for_label }}">Старый пароль</label>
+        {{ form.old_password.as_widget(attrs={'class': 'form-control'}) }}
+        {% if form.old_password.errors %}
+          <div class="text-danger small">{{ form.old_password.errors|striptags }}</div>
+        {% endif %}
       </div>
       <div class="mb-3">
-        <label class="form-label">Новый пароль</label>
-        {{ form.new_password1 }}
+        <label class="form-label" for="{{ form.new_password1.id_for_label }}">Новый пароль</label>
+        {{ form.new_password1.as_widget(attrs={'class': 'form-control'}) }}
+        {% if form.new_password1.errors %}
+          <div class="text-danger small">{{ form.new_password1.errors|striptags }}</div>
+        {% endif %}
       </div>
       <div class="mb-3">
-        <label class="form-label">Подтвердите новый пароль</label>
-        {{ form.new_password2 }}
+        <label class="form-label" for="{{ form.new_password2.id_for_label }}">Подтвердите новый пароль</label>
+        {{ form.new_password2.as_widget(attrs={'class': 'form-control'}) }}
+        {% if form.new_password2.errors %}
+          <div class="text-danger small">{{ form.new_password2.errors|striptags }}</div>
+        {% endif %}
       </div>
       <button class="btn btn-success">Сохранить</button>
     </form>

--- a/core/templates/password_change.html
+++ b/core/templates/password_change.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-4">
+    <h3 class="mb-3">Смена пароля</h3>
+    <form method="post">{% csrf_token %}
+      {{ form.non_field_errors }}
+      <div class="mb-3">
+        <label class="form-label">Старый пароль</label>
+        {{ form.old_password }}
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Новый пароль</label>
+        {{ form.new_password1 }}
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Подтвердите новый пароль</label>
+        {{ form.new_password2 }}
+      </div>
+      <button class="btn btn-success">Сохранить</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/core/templates/password_change_done.html
+++ b/core/templates/password_change_done.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-4 text-center">
+    <h3 class="mb-3">Пароль изменён</h3>
+    <p>Ваш пароль успешно изменён.</p>
+    <a href="{% url 'home' %}" class="btn btn-primary">На главную</a>
+  </div>
+</div>
+{% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -42,9 +42,8 @@ class CustomPasswordChangeView(auth_views.PasswordChangeView):
     success_url = reverse_lazy('password_change_done')
 
     def form_valid(self, form):
-        response = super().form_valid(form)
         self.request.session.pop('force_password_change', None)
-        return response
+        return super().form_valid(form)
 
 # --- роли ---
 # --- роли ---


### PR DESCRIPTION
## Summary
- Force parents and adult students to reset temporary passwords on first login
- Add middleware redirecting flagged users to password change
- Provide templates and routes for password change flow

## Testing
- `python manage.py test`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68a419b74ed083278bfc6690d38b5975