### PR TITLE
Добавить публичную главную страницу со расписанием

### DIFF
--- a/core/static/css/custom.css
+++ b/core/static/css/custom.css
@@ -1,1 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap');
+
 .bg-light-green { background-color: #e6f7e6; }
+
+.landing-title {
+  font-family: 'Playfair Display', serif;
+}

--- a/core/templates/includes/navbar.html
+++ b/core/templates/includes/navbar.html
@@ -25,7 +25,9 @@
           <form method="post" action="{% url 'logout' %}" class="ms-3 d-inline">
             {% csrf_token %}
             <button type="submit" class="btn btn-outline-dark">Выход</button>
-          </form>          
+          </form>
+          {% else %}
+          <a href="{% url 'login' %}" class="btn btn-outline-dark ms-3">Вход</a>
           {% endif %}
         </div>
       </div>

--- a/core/templates/landing.html
+++ b/core/templates/landing.html
@@ -1,0 +1,105 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load get_item %}
+
+{% block content %}
+<div class="text-center py-5">
+  <h1>Спортивный клуб стрельбы из лука "Малыш Джон"</h1>
+  <p class="lead">Мы спортивный клуб стрельбы из традиционного лука. Обучаем стрельбе и погружаем в историю. Помимо тренировок расскажем вам про историю лука с древних времен, различие и особенности. Постоянные тренировки укрепляют здоровье, осанку, тренируют координацию.</p>
+</div>
+
+<div class="container my-5">
+  <h2 class="text-center mb-4">Наши услуги</h2>
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <ul class="list-group">
+        <li class="list-group-item d-flex justify-content-between"><span>Разовое занятие</span><span>800р</span></li>
+        <li class="list-group-item d-flex justify-content-between"><span>Индивидуальное занятие</span><span>1400р</span></li>
+        <li class="list-group-item d-flex justify-content-between"><span>Абонемент 8 занятий/месяц</span><span>5000р</span></li>
+        <li class="list-group-item">Абонементы 12/16 занятий в месяц: индивидуальные условия</li>
+        <li class="list-group-item">Приведи друга: 30% при оформлении абонементов на месяц</li>
+        <li class="list-group-item d-flex justify-content-between"><span>Семейное посещение (до 4 чел)</span><span>2500р</span></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div id="clubCarousel" class="carousel slide mb-5" data-bs-ride="carousel">
+  <div class="carousel-inner">
+    <div class="carousel-item active">
+      <img src="https://via.placeholder.com/800x400?text=Фото+1" class="d-block w-100" alt="...">
+    </div>
+    <div class="carousel-item">
+      <img src="https://via.placeholder.com/800x400?text=Фото+2" class="d-block w-100" alt="...">
+    </div>
+    <div class="carousel-item">
+      <img src="https://via.placeholder.com/800x400?text=Фото+3" class="d-block w-100" alt="...">
+    </div>
+  </div>
+  <button class="carousel-control-prev" type="button" data-bs-target="#clubCarousel" data-bs-slide="prev">
+    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+    <span class="visually-hidden">Previous</span>
+  </button>
+  <button class="carousel-control-next" type="button" data-bs-target="#clubCarousel" data-bs-slide="next">
+    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+    <span class="visually-hidden">Next</span>
+  </button>
+</div>
+
+<div class="container my-5">
+  <h2 class="text-center mb-4">Расписание занятий</h2>
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h5 class="m-0">{% if month %}{{ month|date:"F Y" }}{% endif %}</h5>
+    <div class="d-flex gap-2">
+      <a class="btn btn-sm btn-outline-secondary" href="?year={{ prev_year }}&month={{ prev_month }}">← Предыдущий</a>
+      <a class="btn btn-sm btn-outline-secondary" href="?year={{ next_year }}&month={{ next_month }}">Следующий →</a>
+    </div>
+  </div>
+  <div class="table-responsive">
+    <table class="table table-bordered align-top">
+      <thead class="table-light">
+        <tr class="text-center">
+          <th>Пн</th>
+          <th>Вт</th>
+          <th>Ср</th>
+          <th>Чт</th>
+          <th>Пт</th>
+          <th>Сб</th>
+          <th>Вс</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for week in weeks %}
+          <tr>
+            {% for day in week %}
+              <td style="width:14.28%; vertical-align: top;" class="{% if day and month and day|date:'m' != month|date:'m' %}text-muted bg-light{% endif %}">
+                {% if day %}
+                  <div class="d-flex justify-content-between align-items-center mb-2">
+                    <span class="small fw-semibold">{{ day|date:"d.m" }}</span>
+                  </div>
+                  {% with slots=slots_by_day|get_item:day %}
+                    {% if slots %}
+                      {% for slot in slots %}
+                        <div class="border rounded p-2 mb-2 calendar-slot">
+                          <div class="small fw-semibold">{{ slot.start|date:"H:i" }}–{{ slot.end|date:"H:i" }}</div>
+                          <div class="small mt-1">Занимающихся: {{ slot.participants|length }}</div>
+                        </div>
+                      {% endfor %}
+                    {% endif %}
+                  {% endwith %}
+                {% endif %}
+              </td>
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<footer class="bg-light py-3 mt-5">
+  <div class="container text-center small">
+    ООО "Малыш Джон", ОГРН 0000000000000, ИНН 0000000000, адрес: г. Москва, ул. Примерная, д. 1
+  </div>
+</footer>
+{% endblock %}

--- a/core/templates/landing.html
+++ b/core/templates/landing.html
@@ -3,23 +3,68 @@
 {% load get_item %}
 
 {% block content %}
-<div class="text-center py-5">
-  <h1>Спортивный клуб стрельбы из лука "Малыш Джон"</h1>
-  <p class="lead">Мы спортивный клуб стрельбы из традиционного лука. Обучаем стрельбе и погружаем в историю. Помимо тренировок расскажем вам про историю лука с древних времен, различие и особенности. Постоянные тренировки укрепляют здоровье, осанку, тренируют координацию.</p>
+<div class="container py-5">
+  <h1 class="landing-title text-center mb-4">Спортивный клуб стрельбы из лука "Малыш Джон"</h1>
+  <div class="row align-items-center">
+    <div class="col-md-6 mb-4 mb-md-0">
+      <img src="https://via.placeholder.com/600x400?text=Клуб" class="img-fluid rounded shadow" alt="О клубе">
+    </div>
+    <div class="col-md-6">
+      <p class="lead">Мы спортивный клуб стрельбы из традиционного лука. Обучаем стрельбе и погружаем в историю. Помимо тренировок расскажем вам про историю лука с древних времен, различие и особенности. Постоянные тренировки укрепляют здоровье, осанку, тренируют координацию.</p>
+    </div>
+  </div>
 </div>
 
 <div class="container my-5">
   <h2 class="text-center mb-4">Наши услуги</h2>
-  <div class="row justify-content-center">
-    <div class="col-md-6">
-      <ul class="list-group">
-        <li class="list-group-item d-flex justify-content-between"><span>Разовое занятие</span><span>800р</span></li>
-        <li class="list-group-item d-flex justify-content-between"><span>Индивидуальное занятие</span><span>1400р</span></li>
-        <li class="list-group-item d-flex justify-content-between"><span>Абонемент 8 занятий/месяц</span><span>5000р</span></li>
-        <li class="list-group-item">Абонементы 12/16 занятий в месяц: индивидуальные условия</li>
-        <li class="list-group-item">Приведи друга: 30% при оформлении абонементов на месяц</li>
-        <li class="list-group-item d-flex justify-content-between"><span>Семейное посещение (до 4 чел)</span><span>2500р</span></li>
-      </ul>
+  <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+    <div class="col">
+      <div class="card h-100 text-center">
+        <div class="card-body">
+          <h5 class="card-title">Разовое занятие</h5>
+          <p class="card-text fw-semibold">800р</p>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card h-100 text-center">
+        <div class="card-body">
+          <h5 class="card-title">Индивидуальное занятие</h5>
+          <p class="card-text fw-semibold">1400р</p>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card h-100 text-center">
+        <div class="card-body">
+          <h5 class="card-title">Абонемент 8 занятий/месяц</h5>
+          <p class="card-text fw-semibold">5000р</p>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card h-100 text-center">
+        <div class="card-body">
+          <h5 class="card-title">Абонементы 12/16 занятий в месяц</h5>
+          <p class="card-text">индивидуальные условия</p>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card h-100 text-center">
+        <div class="card-body">
+          <h5 class="card-title">Приведи друга</h5>
+          <p class="card-text">30% при оформлении абонементов на месяц</p>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card h-100 text-center">
+        <div class="card-body">
+          <h5 class="card-title">Семейное посещение (до 4 чел)</h5>
+          <p class="card-text fw-semibold">2500р</p>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/core/views.py
+++ b/core/views.py
@@ -57,11 +57,75 @@ def is_parent(user):
 
 # --- корневая ---
 
-@login_required
 def home(request):
-    if is_admin(request.user):
-        return redirect('admin_dashboard')
-    return redirect('my_schedule')
+    """Публичная главная страница.
+
+    Незарегистрированные пользователи видят лендинг с расписанием,
+    авторизованные перенаправляются в свой раздел.
+    """
+    if request.user.is_authenticated:
+        if is_admin(request.user):
+            return redirect('admin_dashboard')
+        return redirect('my_schedule')
+
+    today = timezone.localdate()
+    try:
+        year = int(request.GET.get('year', today.year))
+        month = int(request.GET.get('month', today.month))
+    except (TypeError, ValueError):
+        year, month = today.year, today.month
+
+    # Нормализуем месяц
+    while month < 1:
+        year -= 1
+        month += 12
+    while month > 12:
+        year += 1
+        month -= 12
+
+    first_day = date(year, month, 1)
+    _, days_in_month = monthrange(year, month)
+    days = [first_day + timedelta(days=i) for i in range(days_in_month)]
+
+    sessions = (
+        TrainingSession.objects
+        .filter(start__year=year, start__month=month)
+        .prefetch_related('participants')
+    )
+    slots_by_day = _group_timeslots(sessions)
+
+    if month == 1:
+        prev_year, prev_month = year - 1, 12
+    else:
+        prev_year, prev_month = year, month - 1
+
+    if month == 12:
+        next_year, next_month = year + 1, 1
+    else:
+        next_year, next_month = year, month + 1
+
+    weeks = []
+    week = []
+    for day in days:
+        week.append(day)
+        if len(week) == 7:
+            weeks.append(week)
+            week = []
+    if week:
+        weeks.append(week)
+
+    context = {
+        'days': days,
+        'month': month,
+        'year': year,
+        'prev_year': prev_year,
+        'prev_month': prev_month,
+        'next_year': next_year,
+        'next_month': next_month,
+        'slots_by_day': slots_by_day,
+        'weeks': weeks,
+    }
+    return render(request, 'landing.html', context)
 
 # --- админ ---
 


### PR DESCRIPTION
## Summary
- Создан лендинг для незарегистрированных пользователей с описанием клуба, услугами и фотокаруселью
- На лендинге отображается расписание занятий за месяц без имён участников
- Авторизованные пользователи перенаправляются на соответствующие разделы

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a431bc01048327b9fed80014ab2f00