### PR TITLE
style: refine parchment price cards

### DIFF
--- a/core/static/css/custom.css
+++ b/core/static/css/custom.css
@@ -8,9 +8,15 @@
 
 /* Parchment styling for price cards */
 .price-card {
-  background: url('../img/parchment.png') center/cover no-repeat;
-  border: 1px solid #d6c5a0;
+  background: url('../img/parchment.png') center/100% 100% no-repeat;
+  border: none;
+  box-shadow: none;
   color: #4a3622;
+}
+
+/* Keep text away from curved scroll edges */
+.price-card .card-body {
+  padding: 1.5rem 2rem;
 }
 
 .price-card .card-title,


### PR DESCRIPTION
## Summary
- remove card borders and shadows on parchment price cards
- ensure parchment image displays fully and add inner padding to avoid edge overlap

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a4893701748327ae4af0c4178d78a0