### PR TITLE
Fix monthly schedule calendar alignment

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,11 @@
+from datetime import date
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+
+class CalendarAlignmentTests(TestCase):
+    def test_month_view_aligns_days_correctly(self):
+        """August 20, 2024 should fall on a Tuesday in the calendar weeks."""
+        response = self.client.get(reverse('home'), {'year': 2024, 'month': 8})
+        weeks = response.context['weeks']
+        self.assertEqual(weeks[3][1], date(2024, 8, 20))

--- a/core/views.py
+++ b/core/views.py
@@ -104,14 +104,16 @@ def home(request):
     else:
         next_year, next_month = year, month + 1
 
+    # Разбиение на недели с учетом дня недели первого числа
     weeks = []
-    week = []
+    week = [None] * first_day.weekday()
     for day in days:
         week.append(day)
         if len(week) == 7:
             weeks.append(week)
             week = []
     if week:
+        week += [None] * (7 - len(week))
         weeks.append(week)
 
     context = {
@@ -206,9 +208,9 @@ def sessions_month(request):
     else:
         next_year, next_month = year, month + 1
 
-    # Разбиение на недели для календаря
+    # Разбиение на недели для календаря с учетом дня недели первого числа
     weeks = []
-    week = []
+    week = [None] * first_day.weekday()
     for day in days:
         week.append(day)
         if len(week) == 7:
@@ -217,6 +219,7 @@ def sessions_month(request):
 
     # Добавить последнюю неполную неделю
     if week:
+        week += [None] * (7 - len(week))
         weeks.append(week)
 
     return render(request, 'admin/sessions_month.html', {


### PR DESCRIPTION
## Summary
- Ensure monthly calendar weeks start on correct weekday
- Add regression test for calendar alignment

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a7c78d648327a4783946b988eb02