### PR TITLE
Allow editing subscription types

### DIFF
--- a/core/templates/admin/subscription_type_edit.html
+++ b/core/templates/admin/subscription_type_edit.html
@@ -1,0 +1,46 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container my-4" style="max-width: 640px;">
+  <div class="card shadow-sm border-0">
+    <div class="card-header" style="background:#d8f3dc;">
+      <h5 class="m-0">Редактировать тип абонемента — {{ stype.name }}</h5>
+    </div>
+    <div class="card-body">
+      <form method="post" novalidate class="grid-form">{% csrf_token %}
+        <div class="mb-3">
+          <label class="form-label" for="{{ form.name.id_for_label }}">Название</label>
+          {{ form.name }}
+          {% if form.name.errors %}
+            <div class="invalid-feedback d-block">{{ form.name.errors|striptags }}</div>
+          {% endif %}
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="{{ form.lessons_count.id_for_label }}">Кол-во занятий</label>
+          <div class="stepper">
+            <button type="button" class="stepper-btn" data-step="-1" aria-label="Уменьшить">−</button>
+            {{ form.lessons_count }}
+            <button type="button" class="stepper-btn" data-step="1" aria-label="Увеличить">+</button>
+          </div>
+          {% if form.lessons_count.errors %}
+            <div class="invalid-feedback d-block">{{ form.lessons_count.errors|striptags }}</div>
+          {% endif %}
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="{{ form.price.id_for_label }}">Цена</label>
+          <div class="input-group">
+            <span class="input-group-text">₽</span>
+            {{ form.price }}
+          </div>
+          {% if form.price.errors %}
+            <div class="invalid-feedback d-block">{{ form.price.errors|striptags }}</div>
+          {% endif %}
+        </div>
+        <div class="text-end">
+          <button class="btn btn-success">Сохранить</button>
+          <a href="{% url 'subscription_types' %}" class="btn btn-outline-secondary ms-2">Отмена</a>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/core/templates/admin/subscription_types.html
+++ b/core/templates/admin/subscription_types.html
@@ -84,6 +84,7 @@
                   <th>Название</th>
                   <th>Занятий</th>
                   <th>Цена</th>
+                  <th class="text-end">Действия</th>
                 </tr>
               </thead>
               <tbody>
@@ -92,10 +93,13 @@
                     <td>{{ t.name }}</td>
                     <td>{{ t.lessons_count }}</td>
                     <td>{{ t.price }}</td>
+                    <td class="text-end">
+                      <a class="btn btn-sm btn-outline-secondary" href="{% url 'subscription_type_edit' t.id %}" title="Редактировать"><i class="bi bi-pencil"></i></a>
+                    </td>
                   </tr>
                 {% empty %}
                   <tr>
-                    <td colspan="3" class="text-muted">Пока нет типов</td>
+                    <td colspan="4" class="text-muted">Пока нет типов</td>
                   </tr>
                 {% endfor %}
               </tbody>

--- a/core/tests.py
+++ b/core/tests.py
@@ -2,6 +2,10 @@ from datetime import date
 from django.test import TestCase
 from django.urls import reverse
 
+from django.contrib.auth.models import User
+from decimal import Decimal
+from .models import SubscriptionType
+
 
 class CalendarAlignmentTests(TestCase):
     def test_month_view_aligns_days_correctly(self):
@@ -9,3 +13,23 @@ class CalendarAlignmentTests(TestCase):
         response = self.client.get(reverse('home'), {'year': 2024, 'month': 8})
         weeks = response.context['weeks']
         self.assertEqual(weeks[3][1], date(2024, 8, 20))
+
+
+class SubscriptionTypeEditTests(TestCase):
+    def setUp(self):
+        self.admin = User.objects.create_user(username='admin', password='pass', is_staff=True)
+        self.type = SubscriptionType.objects.create(name='Basic', lessons_count=8, price=100)
+
+    def test_edit_subscription_type(self):
+        self.client.login(username='admin', password='pass')
+        url = reverse('subscription_type_edit', args=[self.type.pk])
+        response = self.client.post(url, {
+            'name': 'Pro',
+            'lessons_count': 12,
+            'price': '150.00',
+        })
+        self.assertRedirects(response, reverse('subscription_types'))
+        self.type.refresh_from_db()
+        self.assertEqual(self.type.name, 'Pro')
+        self.assertEqual(self.type.lessons_count, 12)
+        self.assertEqual(self.type.price, Decimal('150.00'))

--- a/core/urls.py
+++ b/core/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
 
     path('subscriptions/', views.subscriptions_list, name='subscriptions_list'),
     path('subscription-types/', views.subscription_types, name='subscription_types'),
+    path('subscription-types/<int:pk>/edit/', views.subscription_type_edit, name='subscription_type_edit'),
 
     path('parents/create/', views.parent_create, name='parent_create'),
 

--- a/core/views.py
+++ b/core/views.py
@@ -354,6 +354,20 @@ def subscription_types(request):
 
 @login_required
 @user_passes_test(is_admin)
+def subscription_type_edit(request, pk):
+    stype = get_object_or_404(SubscriptionType, pk=pk)
+    if request.method == 'POST':
+        form = SubscriptionTypeForm(request.POST, instance=stype)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Тип абонемента обновлён')
+            return redirect('subscription_types')
+    else:
+        form = SubscriptionTypeForm(instance=stype)
+    return render(request, 'admin/subscription_type_edit.html', {'form': form, 'stype': stype})
+
+@login_required
+@user_passes_test(is_admin)
 def parent_create(request):
     if request.method == 'POST':
         form = ParentCreateForm(request.POST)


### PR DESCRIPTION
## Summary
- enable editing of subscription types
- show edit option in subscription type list and add dedicated edit page
- test editing subscription types

## Testing
- `python manage.py test core.tests.SubscriptionTypeEditTests core.tests.CalendarAlignmentTests`

------
https://chatgpt.com/codex/tasks/task_e_68a4adba462083279a70b27b043c7034